### PR TITLE
Add error as a slot

### DIFF
--- a/src/components/slds-checkbox/index.vue
+++ b/src/components/slds-checkbox/index.vue
@@ -1,7 +1,7 @@
 <template>
     <div
         class="slds-form-element"
-        :class="{ 'slds-has-error': hasError , 'slds-form-element_readonly': readOnly}">
+        :class="{ 'slds-has-error': error , 'slds-form-element_readonly': readOnly}">
 
         <label v-if="readOnly || isStacked" class="slds-form-element__label">
             <abbr v-if="required" class="slds-required" title="required">* </abbr>{{ label }}
@@ -53,8 +53,8 @@
 
         </div>
 
-        <div v-if="hasError" class="slds-form-element__help">
-            {{ errorMessage }}
+        <div v-if="error" class="slds-form-element__help">
+            <slot name="error"/>
         </div>
 
     </div>
@@ -90,7 +90,7 @@ export default {
             type: String,
         },
 
-        hasError: {
+        error: {
             type: Boolean,
             default: false,
         },


### PR DESCRIPTION
Eu comecei a usar o "slds-input" e vi que ele usa a prop "error" para indicar erro, aí eu acho legal a gente padronizar isso em todos os componentes. Também adicionei o slot "error" por conta dos casos de uso abaixo. Vê o que você acha.

Exemplos: 
1 - Um checkbox pode se tornar required dependendo do valor de outros 2 inputs. Ai dependendo de qual input tornar o checkbox required a mensagem de erro muda. Fazendo como abaixo o cara pode deixar o erro no html ao inves de salvar numa variavel e ficar fazendo swtich entre elas.

```html
<template v-slot:error>
   <p v-if="cond1">Erro 1</p>
   <p v-if="cond2">Erro 2</p>
</template>
````

2 - Ou a mensagem de erro tem um padrão html onde o cara queira inserir um icone. 

```html
<template v-slot:error>
   <p v-if="cond1">Erro 1<slds-svg icon="utility:warning"/></p>
</template>
````