### PR TITLE
Improve global header

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -14,6 +14,7 @@ export {default as sldsCounter} from './slds-counter'
 export {default as sldsDataTable} from './slds-data-table';
 export {default as sldsDockedComposer} from './slds-docked-composer';
 export {default as sldsDuelingPicklist} from './slds-dueling-picklist';
+export {default as sldsGlobalAction} from './slds-global-action'
 export {default as sldsGlobalHeader} from './slds-global-header'
 export {default as sldsGlobalNavigation} from './slds-global-navigation'
 export {default as sldsIcon} from './slds-icon'

--- a/src/components/slds-global-action/index.js
+++ b/src/components/slds-global-action/index.js
@@ -1,0 +1,5 @@
+import sldsComponent from './index.vue'
+
+export default Vue => {
+    Vue.component(sldsComponent.name, sldsComponent)
+}

--- a/src/components/slds-global-action/index.vue
+++ b/src/components/slds-global-action/index.vue
@@ -1,0 +1,33 @@
+<template>
+    <li class="slds-global-actions__item">
+        <div class="slds-dropdown-trigger slds-dropdown-trigger_click">
+            <slds-button-icon
+                :icon="icon"
+                small
+                bare
+                class="slds-global-actions__item-action"
+                aria-haspopup="true"
+                :title="title"/>
+        </div>
+    </li>          
+</template>
+
+<script>
+    import SldsButtonIcon from '../slds-button-icon/index.vue'
+    export default {
+        name: 'SldsGlobalAction',
+        components:{
+            SldsButtonIcon,
+        },
+        props: {
+            icon:{
+                type: String
+            },
+            title:{
+                type: String
+            }
+        }
+    }
+</script>
+
+<style></style>

--- a/src/components/slds-global-header/index.vue
+++ b/src/components/slds-global-header/index.vue
@@ -1,37 +1,88 @@
 <template>
     <header class="slds-global-header_container">
         <div class="slds-global-header slds-grid slds-grid_align-spread">
-
-            <!-- Logo -->
             <div class="slds-global-header__item">
-                <div class="slds-global-header__logo">
-                    <div v-if="name" class="slds-global-header__name">
-                        <span>{{ name }}</span>
+                <div class="slds-grid slds-grid_vertical-align-center">
+                    <div class="slds-col">
+                        <img v-if="brandLogo" :src="brandLogo" alt="logo" :width="`${brandLogoWidth}px`" :height="`${brandLogoHeight}px`">
+                        <div v-else>
+                            <slot name="brand-logo"/>
+                        </div>
+                    </div>
+                    <div class="slds-col" style="white-space:nowrap;">
+                        {{ brandName }}
                     </div>
                 </div>
             </div>
-
-            <!-- Search bar -->
-            <div/>
-
-            <!-- Actions -->
-            <div class="slds-global-header__item">
-                <slot name="actions"/>
+            <div class="slds-global-header__item slds-global-header__item_search">
+                <slot name="search-bar"/>
             </div>
-
+            <div class="slds-global-header__item">
+                <ul class="slds-global-actions">
+                    <slot name="global-actions"/>
+                    <slds-global-action v-if="setupButton" icon="utility:setup" @click="onClickSetup"/>
+                    <slds-global-action v-if="notificationButton" icon="utility:notification" @click="onClickNotification"/>
+                    <li v-if="profileButton" class="slds-global-actions__item" @click="onClickProfile">
+                        <div class="slds-dropdown-trigger slds-dropdown-trigger_click">
+                            <slds-avatar medium circle :src="profilePicture" class="slds-global-actions__avatar slds-global-actions__item-action"/>
+                        </div>
+                    </li>
+                </ul>
+            </div>
         </div>
     </header>
 </template>
 
 <script>
+    import SldsAvatar from '../slds-avatar/index.vue'
+    import SldsGlobalAction from '../slds-global-action/index.vue'
     export default {
         name: 'SldsGlobalHeader',
+        components:{
+            SldsAvatar,
+            SldsGlobalAction
+        },
         props: {
-            name: {
+            brandName: {
                 type: String,
-                default: null,
-                note: 'Name of application'
             },
+            brandLogo:{
+                type: String
+            },
+            brandLogoWidth:{
+                type: Number,
+                default: 35
+            },
+            brandLogoHeight:{
+                type: Number,
+                default: 35
+            },
+            setupButton:{
+                type: Boolean,
+                default: false,
+            },
+            notificationButton:{
+                type: Boolean,
+                default: false,
+            },
+            profileButton: {
+                type: Boolean,
+                default: false,
+            },
+            profilePicture:{
+                type: String
+            }
+        },
+        methods:{
+            onClickSetup(){
+                this.$emit('setup')
+            },
+            onClickNotification(){
+                this.$emit('notification')
+            },
+            onClickProfile(){
+                this.$emit('profile')
+            }
         }
     }
 </script>


### PR DESCRIPTION
Adiciona mais customizações ao componente "slds-global-header". Introduz o componente "slds-global-action" para o usuário poder adicionar botões já formatados para a "global header".

Adiciona os seguinte slots:
```html
<slot name="brand-logo"/> Caso o usuário queira passar uma logo mais complexa como um svg hardcoded em um container.
<slot name="search-bar"/> Caso o usuário queira adicionar uma Search Bar
<slot name="global-actions"/> Caso o usuário queira adicionar mais botoes alem dos seguintes: setup, notification e profile
```

O brand-log também pode ser passado através de uma prop chamada "brand-logo"

Os botões Setup, Notification e Profile são opicionais e podem ser ativados com as seguintes props: setupButton, notificationButton e profileButton. 

Para alterar a foto de perfil basta passar um valor para o atributo "profilePicture"

Eventos emitidos:
this.$emit('profile'); -> ao clicar no botao profile
this.$emit('notification'); -> ao clicar no botao notification
this.$emit('setup'); -> ao clicar no botao setup

<b>Obs:</b> Vou alterar o botao notification usando o "slds-notification", mas ví que também precisa de um "tapa". E o botão profile estou pensando em criar o componente "slds-profile" o que você acha?

<b>Obs:</b> O componente "slds-global-action" eu fiquei em dúvida se fazia ou não, porque meio que dá pra por um slds-button-icon e o resultado é o mesmo. Mas tem a frescura de ser um botao encapsulado num "<li>" porque está dentro de um "<ui>", e também tem umas classes especificas de global action para o global header.