### PR TITLE
Small improvements to standardize the API - slds-checkbox

### DIFF
--- a/src/components/slds-checkbox/index.vue
+++ b/src/components/slds-checkbox/index.vue
@@ -1,16 +1,16 @@
 <template>
     <div
         class="slds-form-element"
-        :class="{ 'slds-has-error': error , 'slds-form-element_readonly': readOnly}">
+        :class="{ 'slds-has-error': error , 'slds-form-element_readonly': readonly}">
 
-        <label v-if="readOnly || isStacked" class="slds-form-element__label">
+        <label v-if="readonly || isStacked" class="slds-form-element__label">
             <abbr v-if="required" class="slds-required" title="required">* </abbr>{{ label }}
         </label>
 
         <div class="slds-form-element__control" @click.stop="onClick">
 
             <!-- Inline faux -->
-            <div v-if="!readOnly && isInline" class="slds-checkbox">
+            <div v-if="!readonly && isInline" class="slds-checkbox">
 
                 <abbr v-if="required" class="slds-required" title="required">* </abbr>
                 <input
@@ -29,7 +29,7 @@
             </div>
 
             <!-- Stacked faux -->
-            <span v-else-if="!readOnly && isStacked" class="slds-checkbox slds-checkbox_standalone">
+            <span v-else-if="!readonly && isStacked" class="slds-checkbox slds-checkbox_standalone">
 
                 <input
                     type="checkbox"
@@ -42,12 +42,12 @@
             </span>
 
             <!-- View mode faux checked-->
-            <span v-else-if="readOnly && checked" class="slds-icon_container slds-icon-utility-check slds-current-color" title="True">
+            <span v-else-if="readonly && checked" class="slds-icon_container slds-icon-utility-check slds-current-color" title="True">
                 <slds-svg icon="utility:check" class="slds-icon slds-icon_x-small"/>
             </span>
 
             <!-- View mode faux unchecked-->
-            <span v-else-if="readOnly && !checked" class="slds-icon_container slds-icon-utility-steps slds-current-color" title="False">
+            <span v-else-if="readonly && !checked" class="slds-icon_container slds-icon-utility-steps slds-current-color" title="False">
                 <slds-svg icon="utility:steps" class="slds-icon slds-icon_x-small"/>
             </span>
 
@@ -65,91 +65,73 @@ import SldsSvg from '../slds-svg/index.vue'
 
 export default {
     name: 'SldsCheckbox',
-
     components: {
         SldsSvg
     },
-
     model: {
         prop: 'checked',
         event: 'input'
     },
-
     props: {
         checked: {
             type: Boolean,
             default: false,
         },
-
         disabled: {
             type: Boolean,
             default: false,
         },
-
-        errorMessage: {
-            type: String,
-        },
-
         error: {
             type: Boolean,
             default: false,
         },
-
-        label: {
-            type: String,
-        },
-
-        readOnly: {
-            type: Boolean,
-            default: false,
-        },
-
-        required: {
-            type: Boolean,
-            default: false,
-        },
-
         inline: {
             type: Boolean,
             default: false
         },
-
+        label: {
+            type: String,
+            default: undefined,
+        },
+        readonly: {
+            type: Boolean,
+            default: false,
+        },
+        required: {
+            type: Boolean,
+            default: false,
+        },
         stacked: {
             type: Boolean,
             default: false
         }
     },
-
     data() {
         return {
-            inputChecked: this.checked,
-            variant: 'inline',
+            inputChecked: this.checked
         }
     },
-
     computed: {
         isStacked() {
             return this.variant === 'stacked'
         },
-
         isInline() {
             return this.variant === 'inline'
+        },
+        variant(){
+            if(this.inline) return 'inline';
+            else if(this.stacked) return 'stacked';
+            else return 'inline';
         }
     },
-
     watch: {
         checked(newValue) {
             this.inputChecked = newValue;
         }
     },
-
-    beforeMount() {
-        if (this.stacked && !this.inline) this.variant = 'stacked'
-    },
-
     methods: {
         onClick() {
-            if (this.disabled || this.readOnly) return;
+            if (this.disabled || this.readonly) return;
             this.inputChecked = !this.inputChecked;
             this.$emit('input', this.inputChecked);
         }


### PR DESCRIPTION
- Mudei de "read-only" para "readonly" para seguir o padrao web da tag "input", e para ficar igual aos outros componentes do vuetning que possuem a prop "readonly".
- Mudei o "variant" para usar uma computed property. Dessa maneira caso o componente já esteja no DOM a gente pode alterar a variant trocando as flags. Obs: Eu voltei ao que era porque fazia mais sentido.
- E tambem organizei as props pra ficar em ordem alfabetica. 
- Retirei a prop "errorMessage" porque que nao estava sendo usado em lugar nenhum. Mensagens de erro ainda pode ser passadas usando o slot "error".