### PR TITLE
When hovering over the checkbox region the cursor changes to a pointer

### DIFF
--- a/src/components/slds-checkbox/index.vue
+++ b/src/components/slds-checkbox/index.vue
@@ -1,6 +1,6 @@
 <template>
     <div
-        class="slds-form-element"
+        class="slds-form-element pointer"
         :class="{ 'slds-has-error': error , 'slds-form-element_readonly': readonly}">
 
         <label v-if="readonly || isStacked" class="slds-form-element__label">
@@ -138,3 +138,17 @@ export default {
     },
 }
 </script>
+
+<style>
+.pointer{
+    cursor: pointer;
+}
+
+.pointer .slds-form-element__label{
+    cursor: pointer;
+}
+
+.pointer .slds-form-element__control{
+    cursor: pointer;
+}
+</style>


### PR DESCRIPTION
- The cursor changes to a Pointer when hovering over the "region" of the input indicating is a clickable element

This is a good improvement but the Lightning Design System does not have it :/

https://github.com/salesforce-ux/design-system/issues/664
