### PR TITLE
Reset package.json version to 0.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vuetning",
-    "version": "0.8.0",
+    "version": "0.0.0",
     "description": "Vue 3 component library implementing the Salesforce Lightning Design System (SLDS).",
     "type": "module",
     "sideEffects": [


### PR DESCRIPTION
## Summary

The publish workflow sets the real version at publish time via `npm version ${{vars.version}}`; the source `package.json` version is meant to stay at `0.0.0` so the bump always detects a change. The BB-2680 PR accidentally introduced `0.8.0` in source, which caused the post-merge publish run on master to fail with `npm error Version not changed`.

This restores the convention.

## Test plan

- [ ] Merge to develop
- [ ] Merge develop → master
- [ ] Confirm Node.js Package workflow succeeds (`vars.version` is `0.8.0`, so `npm version 0.8.0` from a 0.0.0 source will succeed and publish)

🤖 Generated with [Claude Code](https://claude.com/claude-code)