### PR TITLE
Fix publish workflow to tolerate dirty tree

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -15,10 +15,10 @@ jobs:
                   registry-url: https://registry.npmjs.org/
             - run: git config user.email "marceloatg@outlook.com"
             - run: git config user.name "Marcelo Gomes"
-            - run: npm install --no-audit --no-fund
+            - run: npm install --no-audit --no-fund --no-save
             - run: npm run lint
             - run: npm run build
-            - run: npm version ${{vars.version}}
+            - run: npm version --no-git-tag-version ${{vars.version}}
             - run: npm publish
               env:
                   NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
## Summary

After the previous fix the publish workflow advanced to a new error:

```
npm error Git working directory not clean.
```

`npm install` rewrites `package-lock.json` on the Linux runner (the committed lockfile was generated on a different platform), leaving the working tree dirty. `npm version` then refuses to bump.

Two complementary fixes:
- `--no-save` on `npm install` so the lockfile isn't rewritten in CI
- `--no-git-tag-version` on `npm version` so it doesn't gate on a clean tree or create a git tag we don't use

## Test plan

- [ ] Merge to develop, then develop → master
- [ ] Confirm Node.js Package workflow now reaches `npm publish` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)