### PR TITLE
Use shared NPM_TOKEN secret for publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -19,6 +19,6 @@ jobs:
             - run: npm run lint
             - run: npm run build
             - run: npm version --no-git-tag-version ${{vars.version}}
-            - run: npm publish
+            - run: npm publish --access public
               env:
-                  NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

The publish workflow was referencing \`secrets.npm_token\` (lowercase). The greenforce sibling repo uses \`secrets.NPM_TOKEN\` (uppercase) and publishes fine, which strongly suggests \`NPM_TOKEN\` is an org-level shared secret while the lowercase \`npm_token\` was a stale repo-level token that has since expired or lost its publish scope (npm returns 404 instead of 403 in that case, which is what we hit).

Also adds \`--access public\` to \`npm publish\` to match greenforce; harmless for an already-published package and avoids the first-publish trap if it ever applies.

## Test plan

- [ ] Merge to develop, then develop → master
- [ ] Confirm Node.js Package workflow publishes vuetning@0.8.0 to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)