### PR TITLE
Trim dead requirements from GlobalNavigation interfaces

### DIFF
--- a/src/components/slds-global-navigation/global-navigation-sub-tab.ts
+++ b/src/components/slds-global-navigation/global-navigation-sub-tab.ts
@@ -3,9 +3,5 @@ export interface GlobalNavigationSubTab {
 
     isActive: boolean
 
-    isMain: boolean
-
     label: string
-
-    name: string
 }

--- a/src/components/slds-global-navigation/global-navigation-tab.ts
+++ b/src/components/slds-global-navigation/global-navigation-tab.ts
@@ -1,6 +1,4 @@
 export interface GlobalNavigationTab {
-    hasSubTabs: boolean
-
     iconName: string
 
     isActive: boolean


### PR DESCRIPTION
## Summary
Drop `hasSubTabs` from `GlobalNavigationTab` and `isMain` + `name` from `GlobalNavigationSubTab`. None of those fields are actually read anywhere in `slds-global-navigation` or its children:

- `hasSubTabs` is computed locally in `slds-global-navigation.vue` (`subTabs.length > 1`) and forwarded down by prop. The field on the consumer-supplied tab is never accessed.
- `isMain` is derived from the sub-tab's index (`index === 0`) at render time. The field on the consumer-supplied sub-tab is never accessed.
- `name` is not referenced anywhere in the navigation components.

The interfaces were forcing consumers to invent aliases (or duplicate fields) just to satisfy unused requirements. This shrinks the contract to what the component actually consumes.

## Test plan
- [x] `npm run lint`
- [x] `npm run type-check`
- [x] `npm test` (1427/1427)
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)