### PR TITLE
Make falsy-default booleans optional on tab interfaces

### DIFF
--- a/src/components/slds-global-navigation/global-navigation-sub-tab.ts
+++ b/src/components/slds-global-navigation/global-navigation-sub-tab.ts
@@ -1,7 +1,10 @@
 export interface GlobalNavigationSubTab {
     iconName: string
 
-    isActive: boolean
+    /**
+     * Whether this is the active sub-tab. Defaults to false.
+     */
+    isActive?: boolean
 
     label: string
 }

--- a/src/components/slds-global-navigation/global-navigation-tab.ts
+++ b/src/components/slds-global-navigation/global-navigation-tab.ts
@@ -1,7 +1,10 @@
 export interface GlobalNavigationTab {
     iconName: string
 
-    isActive: boolean
+    /**
+     * Whether this is the active tab. Defaults to false.
+     */
+    isActive?: boolean
 
     label: string
 }

--- a/src/components/slds-tabs/tab.ts
+++ b/src/components/slds-tabs/tab.ts
@@ -1,8 +1,8 @@
 export interface Tab {
     /**
-     * Indicates whether this tab has an error icon.
+     * Indicates whether this tab has an error icon. Defaults to false.
      */
-    hasError: boolean
+    hasError?: boolean
 
     /**
      * Tab icon.


### PR DESCRIPTION
## Summary
- `Tab.hasError` (slds-tabs) — `slds-tab.vue` reads it via \`v-if=\"hasError\"\`, treating undefined as no error icon
- `GlobalNavigationTab.isActive` and `GlobalNavigationSubTab.isActive` — `slds-global-navigation.vue` finds the active tab via \`.find(t => t.isActive)\`, treating undefined as not-active

All three are required on the interface today, forcing consumers to write \`hasError: false\` / \`isActive: false\` boilerplate on every tab they construct. Marking them optional keeps the type contract honest with how the components actually consume them.

## Test plan
- [x] \`npm run lint\`
- [x] \`npm run type-check\`
- [x] \`npm test\` (1427/1427)
- [x] \`npm run build\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)