### PR TITLE
Make ScopedTab.hasError optional

### DIFF
--- a/src/components/slds-scoped-tabs/scoped-tab.ts
+++ b/src/components/slds-scoped-tabs/scoped-tab.ts
@@ -1,8 +1,8 @@
 export interface ScopedTab {
     /**
-     * Indicates whether this scoped tab has an error icon.
+     * Indicates whether this scoped tab has an error icon. Defaults to false.
      */
-    hasError: boolean
+    hasError?: boolean
 
     /**
      * Scoped Tab ID


### PR DESCRIPTION
## Summary
\`slds-scoped-tabs.vue\` never forwards \`hasError\` to its child \`slds-scoped-tab\` — the field is dead weight on the consumer contract. Mirroring the recent change to \`Tab\` and \`GlobalNavigation{Tab,SubTab}\`, marking it optional removes \`hasError: false\` boilerplate on every scoped tab.

## Test plan
- [x] \`npm run lint\`
- [x] \`npm run type-check\`
- [x] \`npm test\` (1427/1427)
- [x] \`npm run build\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)