### PR TITLE
Extend VuetningResolver to cover stencils

### DIFF
--- a/src/resolver.test.ts
+++ b/src/resolver.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest"
 
 import * as components from "./components"
-import { componentMap, VuetningResolver } from "./resolver"
+import * as stencils from "./stencils"
+import { componentMap, stencilMap, VuetningResolver } from "./resolver"
 
 describe("VuetningResolver", () => {
     const resolver = VuetningResolver()
@@ -34,11 +35,38 @@ describe("VuetningResolver", () => {
         })
     })
 
+    it("resolves stencils to their stencils/ subpath", () => {
+        expect(resolver.resolve("PlaceholderCard")).toEqual({
+            name: "PlaceholderCard",
+            from: "vuetning/stencils/stencil-card",
+        })
+        expect(resolver.resolve("PlaceholderDataTable")).toEqual({
+            name: "PlaceholderDataTable",
+            from: "vuetning/stencils/stencil-data-table",
+        })
+        expect(resolver.resolve("StencilForm")).toEqual({
+            name: "StencilForm",
+            from: "vuetning/stencils/stencil-form",
+        })
+        expect(resolver.resolve("StencilPageHeader")).toEqual({
+            name: "StencilPageHeader",
+            from: "vuetning/stencils/stencil-page-header",
+        })
+    })
+
     it("respects a custom importPath", () => {
         const customResolver = VuetningResolver({ importPath: "@my/vuetning/components" })
         expect(customResolver.resolve("SldsButton")).toEqual({
             name: "SldsButton",
             from: "@my/vuetning/components/slds-button",
+        })
+    })
+
+    it("respects a custom stencilImportPath", () => {
+        const customResolver = VuetningResolver({ stencilImportPath: "@my/vuetning/stencils" })
+        expect(customResolver.resolve("PlaceholderCard")).toEqual({
+            name: "PlaceholderCard",
+            from: "@my/vuetning/stencils/stencil-card",
         })
     })
 
@@ -53,9 +81,22 @@ describe("VuetningResolver", () => {
         expect(missing).toEqual([])
     })
 
+    it("has an entry for every stencil exported from src/stencils", () => {
+        const exportedNames = Object.keys(stencils)
+        const mapNames = new Set(Object.keys(stencilMap))
+        const missing = exportedNames.filter(name => !mapNames.has(name))
+        expect(missing).toEqual([])
+    })
+
     it("does not declare a subpath for any component that is not exported", () => {
         const exportedNames = new Set(Object.keys(components))
         const orphans = Object.keys(componentMap).filter(name => !exportedNames.has(name))
+        expect(orphans).toEqual([])
+    })
+
+    it("does not declare a subpath for any stencil that is not exported", () => {
+        const exportedNames = new Set(Object.keys(stencils))
+        const orphans = Object.keys(stencilMap).filter(name => !exportedNames.has(name))
         expect(orphans).toEqual([])
     })
 })

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1,7 +1,8 @@
 /**
- * Component-name → subpath map for `unplugin-vue-components`.
- * Must stay in sync with `src/components/index.ts`; the resolver test
- * verifies that every export from the barrel has an entry here.
+ * Component-name → subpath maps for `unplugin-vue-components`.
+ * Both maps must stay in sync with `src/components/index.ts` and
+ * `src/stencils/index.ts`; the resolver test verifies that every export
+ * from each barrel has an entry here.
  */
 export const componentMap: Record<string, string> = {
     SldsAccordion: "slds-accordion",
@@ -88,6 +89,13 @@ export const componentMap: Record<string, string> = {
     SldsWideRadioGroup: "slds-wide-radio-group",
 }
 
+export const stencilMap: Record<string, string> = {
+    PlaceholderCard: "stencil-card",
+    PlaceholderDataTable: "stencil-data-table",
+    StencilForm: "stencil-form",
+    StencilPageHeader: "stencil-page-header",
+}
+
 export interface ComponentInfo {
     name: string
     from: string
@@ -95,15 +103,21 @@ export interface ComponentInfo {
 
 export interface VuetningResolverOptions {
     /**
-     * Override the import path prefix. Defaults to `vuetning/components`.
+     * Override the import path for components. Defaults to `vuetning/components`.
      * Useful for monorepo setups that alias the package locally.
      */
     importPath?: string
+
+    /**
+     * Override the import path for stencils. Defaults to `vuetning/stencils`.
+     */
+    stencilImportPath?: string
 }
 
 /**
  * Resolver for `unplugin-vue-components` that auto-imports vuetning
- * components from their per-component subpaths so tree-shaking still works.
+ * components and stencils from their per-component subpaths so tree-shaking
+ * still works.
  *
  * @example
  * ```ts
@@ -118,12 +132,19 @@ export interface VuetningResolverOptions {
  */
 export function VuetningResolver(options: VuetningResolverOptions = {}) {
     const importPath = options.importPath ?? "vuetning/components"
+    const stencilImportPath = options.stencilImportPath ?? "vuetning/stencils"
     return {
         type: "component" as const,
         resolve(name: string): ComponentInfo | undefined {
-            const subpath = componentMap[name]
-            if (!subpath) return undefined
-            return { name, from: `${importPath}/${subpath}` }
+            const componentSubpath = componentMap[name]
+            if (componentSubpath) {
+                return { name, from: `${importPath}/${componentSubpath}` }
+            }
+            const stencilSubpath = stencilMap[name]
+            if (stencilSubpath) {
+                return { name, from: `${stencilImportPath}/${stencilSubpath}` }
+            }
+            return undefined
         },
     }
 }


### PR DESCRIPTION
## Summary
The resolver only knew about \`Slds*\` components, so stencils (\`PlaceholderCard\`, \`PlaceholderDataTable\`, \`StencilForm\`, \`StencilPageHeader\`) went unresolved when consumers dropped the global \`app.use(vuetning)\` plugin in favor of \`unplugin-vue-components\` auto-import. Vue warns \`Failed to resolve component: placeholder-card\` at render time, and the placeholder simply doesn't render.

- Add \`stencilMap\` with the four stencil exports
- Resolve stencils to \`vuetning/stencils/<dir>\`; default overridable via the new \`stencilImportPath\` option (mirrors \`importPath\`)
- Extend the resolver tests with stencil resolution + barrel-drift guards (mirroring the components-side checks)

Reproduces in the user / admin apps; once 0.8.5 is published, no consumer-side changes are needed — the resolver just starts handling the stencil tags.

## Test plan
- [x] \`npm run lint\`
- [x] \`npm run type-check\`
- [x] \`npm test\` (1431/1431, +4 new assertions)
- [x] \`npm run build\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)