### PR TITLE
Promote required peers to regular dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
         "test:ssr": "vitest run --config vitest.ssr.config.ts",
         "type-check": "vue-tsc --noEmit --composite false"
     },
-    "peerDependencies": {
+    "dependencies": {
         "@formkit/auto-animate": "^0.9.0",
         "@vueuse/components": "^14.2.1",
         "@vueuse/core": "^14.2.1",
@@ -88,37 +88,10 @@
         "numeral": "^2.0.6",
         "scrollparent": "^2.1.0",
         "uuid": "^14.0.0",
-        "vue": "^3.5.33",
         "vue-observe-visibility": "^2.0.0-alpha.1"
     },
-    "peerDependenciesMeta": {
-        "@formkit/auto-animate": {
-            "optional": true
-        },
-        "@vueuse/components": {
-            "optional": true
-        },
-        "@vueuse/core": {
-            "optional": true
-        },
-        "gsap": {
-            "optional": true
-        },
-        "moment": {
-            "optional": true
-        },
-        "numeral": {
-            "optional": true
-        },
-        "scrollparent": {
-            "optional": true
-        },
-        "uuid": {
-            "optional": true
-        },
-        "vue-observe-visibility": {
-            "optional": true
-        }
+    "peerDependencies": {
+        "vue": "^3.5.33"
     },
     "devDependencies": {
         "@eslint/js": "^10.0.1",


### PR DESCRIPTION
## Summary
- Every previously-optional peer dep (`gsap`, `moment`, `numeral`, `@vueuse/core`, `@vueuse/components`, `@formkit/auto-animate`, `scrollparent`, `uuid`, `vue-observe-visibility`) is unconditionally imported at module top by at least one component, so consumers were shipping broken bundles when those components rendered (e.g. `Could not resolve "gsap" imported by "vuetning"` when `<slds-dropdown>` is used).
- Moved all nine to `dependencies` so they install transitively — consumers no longer have to guess what to add to their own `package.json`.
- Kept `vue` as the sole peer dep to avoid duplicate Vue instances. Removed the now-empty `peerDependenciesMeta`.
- Bundle size is unaffected: tree-shaking still drops libs reached only through unused components (verified against `ursus.web.signup`'s build — only `gsap` ends up in the bundle because only `slds-dropdown` is rendered).

## Test plan
- [ ] `npm install` in a fresh consumer project succeeds without peer-dep warnings for the nine libs
- [ ] `ursus.web.signup` production build (`npm run build:hom`) no longer errors on `gsap`
- [ ] Render `<slds-dropdown>` in a consumer that previously omitted `gsap` — confirm the enter animation works
- [ ] Spot-check that consumer bundles for apps not using `slds-data-table` / `slds-datepicker` still exclude `numeral` and `moment` (tree-shaking intact)